### PR TITLE
Refactored library

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -13,8 +13,9 @@ return PhpCsFixer\Config::create()
         'declare_strict_types' => true,
         'is_null' => ['use_yoda_style' => false],
         'list_syntax' => ['syntax' => 'short'],
+        'method_argument_space' => ['ensure_fully_multiline' => true],
         'modernize_types_casting' => true,
-//        'no_multiline_whitespace_before_semicolon' => true,
+        'no_multiline_whitespace_before_semicolons' => true,
         'no_useless_else' => true,
         'no_useless_return' => true,
         'ordered_imports' => true,
@@ -23,8 +24,9 @@ return PhpCsFixer\Config::create()
         'php_unit_construct' => true,
         'php_unit_dedicate_assert' => true,
         'pre_increment' => false,
+        'single_line_comment_style' => true,
         'ternary_to_null_coalescing' => true,
-//        'void_return' => true,
+        'void_return' => true,
     ])
     ->setFinder($finder)
     ->setUsingCache(true)

--- a/README.md
+++ b/README.md
@@ -25,53 +25,6 @@ run PHPUnit.
     $ composer install
     $ vendor/bin/phpunit
 
-HashMap
--------
-
-This data structure is similar to key-value pair, but allows you to store an object
-as the key, unlike normal PHP arrays. Internally, objects are compared using their
-unique hash. To help you understand this better:
-
-```php
-<?php
-
-use Linio\Type\HashMap;
-
-$obj1 = new \StdClass();
-$obj2 = new \StdClass();
-$hashMap = new HashMap();
-$hashMap->set($obj1, 'foo');
-$hashMap->set($obj2, 'bar');
-
-$hashMap->get($obj1); // foo
-$hashMap->get($obj2); // bar
-```
-
-ValueHashMap
-------------
-
-Inheriting from the `HashMap` data structure, this variant allows you to store objects
-in exactly the same way, except that objects will be compared by value. A common
-use case is:
-
-```php
-<?php
-
-use Linio\Type\ValueHashMap;
-
-$firstDay = new \DateTime('2000-01-01 00:00:00');
-$secondDay = new \DateTime('2000-01-01 00:00:00');
-$thirdDay = new \DateTime('2000-01-20 00:00:00');
-
-$hashMap = new ValueHashMap();
-$hashMap->set($secondDay, 'foo');
-$hashMap->set($thirdDay, 'bar');
-
-$hashMap->get($firstDay); // foo
-$hashMap->get($secondDay); // foo
-$hashMap->get($thirdDay); // bar
-```
-
 Dictionary
 ----------
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ in an idiomatic way:
 ```php
 <?php
 
-use Linio\Type\Dictionary;
+use Linio\Common\Type\Dictionary;
 
 $dict = new Dictionary(['foo' => 'bar']);
 
@@ -65,13 +65,13 @@ implementing a type validation method. For example:
 ```php
 <?php
 
-use Linio\Collection\TypedCollection;
+use Linio\Common\Type\Collection\TypedCollection;
 
 class UserCollection extends TypedCollection
 {
-    public function isValidType($value)
+    public function isValidType($value): bool
     {
-        return ($value instanceof User);
+        return $value instanceof User;
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -5,9 +5,7 @@ Linio Common
 Linio Common contains small components that either extend PHP's functionality or provide
 a coherent base for Linio components:
 
-* Service traits
-* Controller helper methods
-* Types, collections
+* Common & Collection Types
 
 Install
 -------

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "phpunit/phpunit": "^5.0",
         "doctrine/orm": "^2.5",
         "gedmo/doctrine-extensions": "^2.3",
-        "friendsofphp/php-cs-fixer": "^2.0"
+        "friendsofphp/php-cs-fixer": "^2.4"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "doctrine/collections": "^1.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.0",
+        "phpunit/phpunit": "^6.0",
         "doctrine/orm": "^2.5",
         "gedmo/doctrine-extensions": "^2.3",
         "friendsofphp/php-cs-fixer": "^2.4"

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,6 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0",
-        "doctrine/orm": "^2.5",
-        "gedmo/doctrine-extensions": "^2.3",
         "friendsofphp/php-cs-fixer": "^2.4"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
     },
     "autoload": {
         "psr-4": {
-            "Linio\\Common\\": "src/"
+            "Linio\\Common\\": "src/",
+            "Linio\\": "forwardCompatibility/"
         }
     },
     "autoload-dev": {

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,5 @@
         "psr-4": {
             "Linio\\Common\\": "tests/"
         }
-    },
-    "minimum-stability": "dev",
-    "prefer-stable": true
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,12 @@
     },
     "autoload": {
         "psr-4": {
-            "Linio\\": "src"
+            "Linio\\Common\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "Linio\\": "tests"
+            "Linio\\Common\\": "tests/"
         }
     },
     "minimum-stability": "dev",

--- a/forwardCompatibility/Collection/FixedTypedCollection.php
+++ b/forwardCompatibility/Collection/FixedTypedCollection.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Linio\Collection;
 
-abstract class FixedTypedCollection extends \Linio\Common\Collection\FixedTypedCollection
+abstract class FixedTypedCollection extends \Linio\Common\Type\Collection\FixedTypedCollection
 {
 }

--- a/forwardCompatibility/Collection/FixedTypedCollection.php
+++ b/forwardCompatibility/Collection/FixedTypedCollection.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Linio\Collection;
 
+/**
+ * @deprecated in 3.0 to be removed in 4.0. Use \Linio\Common\Type\Collection\FixedTypedCollection instead.
+ */
 abstract class FixedTypedCollection extends \Linio\Common\Type\Collection\FixedTypedCollection
 {
 }

--- a/forwardCompatibility/Collection/FixedTypedCollection.php
+++ b/forwardCompatibility/Collection/FixedTypedCollection.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Linio\Collection;
+
+abstract class FixedTypedCollection extends \Linio\Common\Collection\FixedTypedCollection
+{
+}

--- a/forwardCompatibility/Collection/TypedCollection.php
+++ b/forwardCompatibility/Collection/TypedCollection.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Linio\Collection;
 
+/**
+ * @deprecated in 3.0 to be removed in 4.0. Use \Linio\Common\Type\Collection\TypedCollection instead.
+ */
 abstract class TypedCollection extends \Linio\Common\Type\Collection\TypedCollection
 {
 

--- a/forwardCompatibility/Collection/TypedCollection.php
+++ b/forwardCompatibility/Collection/TypedCollection.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Linio\Collection;
 
-abstract class TypedCollection extends \Linio\Common\Collection\TypedCollection
+abstract class TypedCollection extends \Linio\Common\Type\Collection\TypedCollection
 {
 
 }

--- a/forwardCompatibility/Collection/TypedCollection.php
+++ b/forwardCompatibility/Collection/TypedCollection.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Linio\Collection;
+
+abstract class TypedCollection extends \Linio\Common\Collection\TypedCollection
+{
+
+}

--- a/forwardCompatibility/Type/Address.php
+++ b/forwardCompatibility/Type/Address.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Linio\Type;
+
+class Address extends \Linio\Common\Type\Address
+{
+
+}

--- a/forwardCompatibility/Type/Address.php
+++ b/forwardCompatibility/Type/Address.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Linio\Type;
 
+/**
+ * @deprecated in 3.0 to be removed in 4.0. Use \Linio\Common\Type\Address instead.
+ */
 class Address extends \Linio\Common\Type\Address
 {
-
 }

--- a/forwardCompatibility/Type/Date.php
+++ b/forwardCompatibility/Type/Date.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Linio\Type;
 
+/**
+ * @deprecated in 3.0 to be removed in 4.0. Use \Linio\Common\Type\Date instead.
+ */
 class Date extends \Linio\Common\Type\Date
 {
-
 }

--- a/forwardCompatibility/Type/Date.php
+++ b/forwardCompatibility/Type/Date.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Linio\Type;
+
+class Date extends \Linio\Common\Type\Date
+{
+
+}

--- a/forwardCompatibility/Type/Dictionary.php
+++ b/forwardCompatibility/Type/Dictionary.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Linio\Type;
+
+class Dictionary extends \Linio\Common\Type\Dictionary
+{
+
+}

--- a/forwardCompatibility/Type/Dictionary.php
+++ b/forwardCompatibility/Type/Dictionary.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Linio\Type;
 
+/**
+ * @deprecated in 3.0 to be removed in 4.0. Use \Linio\Common\Type\Dictionary instead.
+ */
 class Dictionary extends \Linio\Common\Type\Dictionary
 {
-
 }

--- a/forwardCompatibility/Type/Money.php
+++ b/forwardCompatibility/Type/Money.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Linio\Type;
 
+/**
+ * @deprecated in 3.0 to be removed in 4.0. Use \Linio\Common\Type\Money instead.
+ */
 class Money extends \Linio\Common\Type\Money
 {
-
 }

--- a/forwardCompatibility/Type/Money.php
+++ b/forwardCompatibility/Type/Money.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Linio\Type;
+
+class Money extends \Linio\Common\Type\Money
+{
+
+}

--- a/forwardCompatibility/Type/PreciseMoney.php
+++ b/forwardCompatibility/Type/PreciseMoney.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Linio\Type;
+
+class PreciseMoney extends \Linio\Common\Type\PreciseMoney
+{
+
+}

--- a/forwardCompatibility/Type/PreciseMoney.php
+++ b/forwardCompatibility/Type/PreciseMoney.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Linio\Type;
 
+/**
+ * @deprecated in 3.0 to be removed in 4.0. Use \Linio\Common\Type\PreciseMoney instead.
+ */
 class PreciseMoney extends \Linio\Common\Type\PreciseMoney
 {
-
 }

--- a/forwardCompatibility/Type/Time.php
+++ b/forwardCompatibility/Type/Time.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Linio\Type;
+
+class Time extends \Linio\Common\Type\Time
+{
+
+}

--- a/forwardCompatibility/Type/Time.php
+++ b/forwardCompatibility/Type/Time.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Linio\Type;
 
+/**
+ * @deprecated in 3.0 to be removed in 4.0. Use \Linio\Common\Type\Time instead.
+ */
 class Time extends \Linio\Common\Type\Time
 {
-
 }

--- a/src/Collection/FixedTypedCollection.php
+++ b/src/Collection/FixedTypedCollection.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Linio\Collection;
+namespace Linio\Common\Collection;
 
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\Common\Collections\Expr\ClosureExpressionVisitor;

--- a/src/Collection/TypedCollection.php
+++ b/src/Collection/TypedCollection.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Linio\Collection;
+namespace Linio\Common\Collection;
 
 use Doctrine\Common\Collections\ArrayCollection;
 

--- a/src/Type/Address.php
+++ b/src/Type/Address.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Linio\Type;
+namespace Linio\Common\Type;
 
 class Address
 {

--- a/src/Type/Address.php
+++ b/src/Type/Address.php
@@ -36,67 +36,71 @@ class Address
      */
     protected $country;
 
-    public function getLine1(): string
+    public function getLine1(): ?string
     {
         return $this->line1;
     }
 
-    public function setLine1(string $line1)
+    public function setLine1(string $line1): void
     {
         $this->line1 = $line1;
     }
 
-    public function getLine2(): string
+    public function getLine2(): ?string
     {
         return $this->line2;
     }
 
-    public function setLine2(string $line2)
+    public function setLine2(string $line2): void
     {
         $this->line2 = $line2;
     }
 
-    public function getFullAddress(): string
+    public function getFullAddress(): ?string
     {
+        if (!$this->line1 && !$this->line2) {
+            return null;
+        }
+
         return $this->line1 . ' ' . $this->line2;
     }
 
-    public function getPostcode(): string
+    public function getPostcode(): ?string
     {
         return $this->postcode;
     }
 
-    public function setPostcode(string $postcode)
+    public function setPostcode(string $postcode): void
     {
         $this->postcode = $postcode;
     }
 
-    public function getCity(): string
+    public function getCity(): ?string
     {
         return $this->city;
     }
 
-    public function setCity(string $city)
+    public function setCity(string $city): void
     {
         $this->city = $city;
     }
 
-    public function getState(): string
+    public function getState(): ?string
     {
         return $this->state;
     }
 
-    public function setState(string $state)
+    public function setState(string $state): void
     {
         $this->state = $state;
     }
 
-    public function getCountry(): string
+    public function getCountry(): ?string
     {
         return $this->country;
     }
 
-    public function setCountry(string $country)
+    public function setCountry(string $country): void
     {
         $this->country = $country;
     }

--- a/src/Type/Collection/FixedTypedCollection.php
+++ b/src/Type/Collection/FixedTypedCollection.php
@@ -2,10 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Linio\Common\Collection;
+namespace Linio\Common\Type\Collection;
 
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\Common\Collections\Expr\ClosureExpressionVisitor;
+use InvalidArgumentException;
+use Linio\Common\Type\Collection\TypedCollection;
 
 abstract class FixedTypedCollection extends TypedCollection
 {
@@ -15,24 +17,25 @@ abstract class FixedTypedCollection extends TypedCollection
     protected $size;
 
     /**
-     * @param int   $size
-     * @param array $elements
+     * {@inheritdoc}
+     *
+     * @throws InvalidArgumentException
      */
-    public function __construct($size, array $elements = [])
+    public function __construct(int $size, array $elements = [])
     {
-        $this->size = (int) $size;
+        $this->size = $size;
 
         parent::__construct($elements);
 
         if ($this->count() > $this->size) {
-            throw new \InvalidArgumentException('Index invalid or out of range');
+            throw new InvalidArgumentException('Index invalid or out of range');
         }
     }
 
     /**
      * {@inheritdoc}
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         $this->validateSize();
         parent::offsetSet($offset, $value);
@@ -41,14 +44,14 @@ abstract class FixedTypedCollection extends TypedCollection
     /**
      * @param int|string $key
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      *
      * @return mixed|null
      */
     public function get($key)
     {
         if (!$this->containsKey($key)) {
-            throw new \InvalidArgumentException('Index invalid or out of range');
+            throw new InvalidArgumentException('Index invalid or out of range');
         }
 
         return parent::get($key);
@@ -65,19 +68,19 @@ abstract class FixedTypedCollection extends TypedCollection
     /**
      * {@inheritdoc}
      */
-    public function add($value)
+    public function add($value): void
     {
         $this->validateSize();
         parent::add($value);
     }
 
     /**
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      */
-    protected function validateSize()
+    protected function validateSize(): void
     {
         if ($this->count() >= $this->size) {
-            throw new \InvalidArgumentException('Index invalid or out of range');
+            throw new InvalidArgumentException('Index invalid or out of range');
         }
     }
 

--- a/src/Type/Collection/FixedTypedCollection.php
+++ b/src/Type/Collection/FixedTypedCollection.php
@@ -7,7 +7,6 @@ namespace Linio\Common\Type\Collection;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\Common\Collections\Expr\ClosureExpressionVisitor;
 use InvalidArgumentException;
-use Linio\Common\Type\Collection\TypedCollection;
 
 abstract class FixedTypedCollection extends TypedCollection
 {

--- a/src/Type/Collection/TypedCollection.php
+++ b/src/Type/Collection/TypedCollection.php
@@ -2,9 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Linio\Common\Collection;
+namespace Linio\Common\Type\Collection;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use InvalidArgumentException;
 
 abstract class TypedCollection extends ArrayCollection
 {
@@ -23,7 +24,7 @@ abstract class TypedCollection extends ArrayCollection
     /**
      * {@inheritdoc}
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         $this->validateType($value);
         parent::offsetSet($offset, $value);
@@ -32,29 +33,22 @@ abstract class TypedCollection extends ArrayCollection
     /**
      * {@inheritdoc}
      */
-    public function add($value)
+    public function add($value): void
     {
         $this->validateType($value);
         parent::add($value);
     }
 
     /**
-     * @param mixed $value
-     *
      * @throws InvalidArgumentException
      */
-    protected function validateType($value)
+    protected function validateType($value): void
     {
         if (!$this->isValidType($value)) {
             $type = is_object($value) ? get_class($value) : gettype($value);
-            throw new \InvalidArgumentException('Unsupported type: ' . $type);
+            throw new InvalidArgumentException('Unsupported type: ' . $type);
         }
     }
 
-    /**
-     * @param mixed $value
-     *
-     * @return bool
-     */
-    abstract public function isValidType($value);
+    abstract public function isValidType($value): bool;
 }

--- a/src/Type/Date.php
+++ b/src/Type/Date.php
@@ -4,15 +4,18 @@ declare(strict_types=1);
 
 namespace Linio\Common\Type;
 
-class Date extends \DateTime
+use DateTime;
+use DateTimeZone;
+
+class Date extends DateTime
 {
-    public function __construct(string $time = 'now', \DateTimeZone $timezone = null)
+    public function __construct(string $time = 'now', DateTimeZone $timezone = null)
     {
         parent::__construct($time, $timezone);
         $this->setTime(0, 0, 0);
     }
 
-    public static function createFromDateTime(\DateTime $dateTime): Date
+    public static function createFromDateTime(DateTime $dateTime): Date
     {
         return new self($dateTime->format('Y-m-d'));
     }

--- a/src/Type/Date.php
+++ b/src/Type/Date.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Linio\Type;
+namespace Linio\Common\Type;
 
 class Date extends \DateTime
 {

--- a/src/Type/Dictionary.php
+++ b/src/Type/Dictionary.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace Linio\Common\Type;
 
-class Dictionary implements \JsonSerializable, \Countable
+use Countable;
+use JsonSerializable;
+
+class Dictionary implements JsonSerializable, Countable
 {
     /**
      * @var array
@@ -25,12 +28,12 @@ class Dictionary implements \JsonSerializable, \Countable
         return $this->data[$key];
     }
 
-    public function set(string $key, $value)
+    public function set(string $key, $value): void
     {
         $this->data[$key] = $value;
     }
 
-    public function remove(string $key)
+    public function remove(string $key): void
     {
         unset($this->data[$key]);
     }
@@ -45,7 +48,7 @@ class Dictionary implements \JsonSerializable, \Countable
         return in_array($value, $this->data);
     }
 
-    public function replace(array $data)
+    public function replace(array $data): void
     {
         $this->data = $data;
     }
@@ -65,7 +68,7 @@ class Dictionary implements \JsonSerializable, \Countable
         return count($this->data);
     }
 
-    public function clear()
+    public function clear(): void
     {
         $this->data = [];
     }

--- a/src/Type/Dictionary.php
+++ b/src/Type/Dictionary.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Linio\Type;
+namespace Linio\Common\Type;
 
 class Dictionary implements \JsonSerializable, \Countable
 {

--- a/src/Type/Money.php
+++ b/src/Type/Money.php
@@ -137,7 +137,7 @@ class Money
         return $this->amount;
     }
 
-    public function setAmount(float $amount)
+    public function setAmount(float $amount): void
     {
         $this->amount = (int) round($amount);
     }
@@ -147,7 +147,7 @@ class Money
         return $this->scale;
     }
 
-    public function setScale(int $scale)
+    public function setScale(int $scale): void
     {
         $this->scale = $scale;
     }

--- a/src/Type/Money.php
+++ b/src/Type/Money.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Linio\Type;
+namespace Linio\Common\Type;
 
 class Money
 {

--- a/src/Type/PreciseMoney.php
+++ b/src/Type/PreciseMoney.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Linio\Type;
+namespace Linio\Common\Type;
 
 class PreciseMoney extends Money
 {

--- a/src/Type/PreciseMoney.php
+++ b/src/Type/PreciseMoney.php
@@ -110,7 +110,7 @@ class PreciseMoney extends Money
         return (int) round($this->amount);
     }
 
-    public function setAmount(float $amount)
+    public function setAmount(float $amount): void
     {
         $this->amount = (string) $amount;
     }

--- a/src/Type/Time.php
+++ b/src/Type/Time.php
@@ -4,15 +4,18 @@ declare(strict_types=1);
 
 namespace Linio\Common\Type;
 
-class Time extends \DateTime
+use DateTime;
+use DateTimeZone;
+
+class Time extends DateTime
 {
-    public function __construct(string $time = 'now', \DateTimeZone $timezone = null)
+    public function __construct(string $time = 'now', DateTimeZone $timezone = null)
     {
         parent::__construct($time, $timezone);
         $this->setDate(1970, 1, 1);
     }
 
-    public static function createFromDateTime(\DateTime $dateTime): Time
+    public static function createFromDateTime(DateTime $dateTime): Time
     {
         return new self($dateTime->format('H:i:s'));
     }

--- a/src/Type/Time.php
+++ b/src/Type/Time.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Linio\Type;
+namespace Linio\Common\Type;
 
 class Time extends \DateTime
 {

--- a/tests/Collection/FixedTypedCollectionTest.php
+++ b/tests/Collection/FixedTypedCollectionTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Linio\Collection;
+namespace Linio\Common\Collection;
 
 class FixedTypedCollectionTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Collection/TypedCollectionTest.php
+++ b/tests/Collection/TypedCollectionTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Linio\Collection;
+namespace Linio\Common\Collection;
 
 class TypedCollectionTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Type/AddressTest.php
+++ b/tests/Type/AddressTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Linio\Common\Type;
 
-class AddressTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class AddressTest extends TestCase
 {
     public function testIsGettingFullAddress(): void
     {

--- a/tests/Type/AddressTest.php
+++ b/tests/Type/AddressTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Linio\Type;
+namespace Linio\Common\Type;
 
 class AddressTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Type/AddressTest.php
+++ b/tests/Type/AddressTest.php
@@ -6,7 +6,7 @@ namespace Linio\Common\Type;
 
 class AddressTest extends \PHPUnit_Framework_TestCase
 {
-    public function testIsGettingFullAddress()
+    public function testIsGettingFullAddress(): void
     {
         $address = new Address();
         $address->setLine1('foo');

--- a/tests/Type/Collection/FixedTypedCollectionTest.php
+++ b/tests/Type/Collection/FixedTypedCollectionTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Linio\Common\Type\Collection;
 
-class FixedTypedCollectionTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class FixedTypedCollectionTest extends TestCase
 {
     /**
      * @expectedException \InvalidArgumentException

--- a/tests/Type/Collection/FixedTypedCollectionTest.php
+++ b/tests/Type/Collection/FixedTypedCollectionTest.php
@@ -10,7 +10,7 @@ class FixedTypedCollectionTest extends \PHPUnit_Framework_TestCase
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage Index invalid or out of range
      */
-    public function testIsValidatingSizeOnConstructor()
+    public function testIsValidatingSizeOnConstructor(): void
     {
         $collection = $this->getMockForAbstractClass('Linio\Collection\FixedTypedCollection', [], '', false);
         $collection->expects($this->at(0))
@@ -27,7 +27,7 @@ class FixedTypedCollectionTest extends \PHPUnit_Framework_TestCase
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage Index invalid or out of range
      */
-    public function testIsValidatingSizeOnOffsetSet()
+    public function testIsValidatingSizeOnOffsetSet(): void
     {
         $collection = $this->getMockForAbstractClass('Linio\Collection\FixedTypedCollection', [], '', false);
         $collection->__construct(0);
@@ -39,7 +39,7 @@ class FixedTypedCollectionTest extends \PHPUnit_Framework_TestCase
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage Index invalid or out of range
      */
-    public function testIsValidatingSizeOnAdd()
+    public function testIsValidatingSizeOnAdd(): void
     {
         $collection = $this->getMockForAbstractClass('Linio\Collection\FixedTypedCollection', [], '', false);
         $collection->__construct(0);
@@ -47,7 +47,7 @@ class FixedTypedCollectionTest extends \PHPUnit_Framework_TestCase
         $collection->add('foo');
     }
 
-    public function testIsGetting()
+    public function testIsGetting(): void
     {
         $collection = $this->getMockForAbstractClass('Linio\Collection\FixedTypedCollection', [], '', false);
         $collection->expects($this->at(0))
@@ -64,7 +64,7 @@ class FixedTypedCollectionTest extends \PHPUnit_Framework_TestCase
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage Index invalid or out of range
      */
-    public function testIsValidatingKeyOnGet()
+    public function testIsValidatingKeyOnGet(): void
     {
         $collection = $this->getMockForAbstractClass('Linio\Collection\FixedTypedCollection', [], '', false);
         $collection->__construct(1);
@@ -76,7 +76,7 @@ class FixedTypedCollectionTest extends \PHPUnit_Framework_TestCase
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage Index invalid or out of range
      */
-    public function testIsValidatingKeyOnOffsetGet()
+    public function testIsValidatingKeyOnOffsetGet(): void
     {
         $collection = $this->getMockForAbstractClass('Linio\Collection\FixedTypedCollection', [], '', false);
         $collection->__construct(1);
@@ -84,7 +84,7 @@ class FixedTypedCollectionTest extends \PHPUnit_Framework_TestCase
         $collection[2];
     }
 
-    public function testIsApplyingMatchingCriteria()
+    public function testIsApplyingMatchingCriteria(): void
     {
         $criteria = $this->getMockBuilder(
             '\Doctrine\Common\Collections\Criteria',

--- a/tests/Type/Collection/FixedTypedCollectionTest.php
+++ b/tests/Type/Collection/FixedTypedCollectionTest.php
@@ -17,7 +17,7 @@ class FixedTypedCollectionTest extends TestCase
         $object2 = new class {};
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage("Index invalid or out of range");
+        $this->expectExceptionMessage('Index invalid or out of range');
 
         new class(1, [$object1, $object2]) extends FixedTypedCollection {
             public function isValidType($value): bool
@@ -37,7 +37,7 @@ class FixedTypedCollectionTest extends TestCase
         };
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage("Index invalid or out of range");
+        $this->expectExceptionMessage('Index invalid or out of range');
 
         $collection[] = new class {};
     }
@@ -54,7 +54,7 @@ class FixedTypedCollectionTest extends TestCase
         };
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage("Index invalid or out of range");
+        $this->expectExceptionMessage('Index invalid or out of range');
 
         $collection->add($object1);
     }
@@ -85,7 +85,7 @@ class FixedTypedCollectionTest extends TestCase
         };
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage("Index invalid or out of range");
+        $this->expectExceptionMessage('Index invalid or out of range');
 
         $collection->get(1);
     }
@@ -104,7 +104,7 @@ class FixedTypedCollectionTest extends TestCase
         };
 
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage("Index invalid or out of range");
+        $this->expectExceptionMessage('Index invalid or out of range');
 
         $collection[2];
     }

--- a/tests/Type/Collection/FixedTypedCollectionTest.php
+++ b/tests/Type/Collection/FixedTypedCollectionTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Linio\Common\Collection;
+namespace Linio\Common\Type\Collection;
 
 class FixedTypedCollectionTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Type/Collection/FixedTypedCollectionTest.php
+++ b/tests/Type/Collection/FixedTypedCollectionTest.php
@@ -13,8 +13,10 @@ class FixedTypedCollectionTest extends TestCase
 {
     public function testIsValidatingSizeOnConstructor(): void
     {
-        $object1 = new class {};
-        $object2 = new class {};
+        $object1 = new class() {
+        };
+        $object2 = new class() {
+        };
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Index invalid or out of range');
@@ -39,12 +41,14 @@ class FixedTypedCollectionTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Index invalid or out of range');
 
-        $collection[] = new class {};
+        $collection[] = new class() {
+        };
     }
 
     public function testIsValidatingSizeOnAdd(): void
     {
-        $object1 = new class {};
+        $object1 = new class() {
+        };
 
         $collection = new class(0) extends FixedTypedCollection {
             public function isValidType($value): bool
@@ -61,7 +65,8 @@ class FixedTypedCollectionTest extends TestCase
 
     public function testIsGetting(): void
     {
-        $object1 = new class {};
+        $object1 = new class() {
+        };
 
         $collection = new class(1, [$object1]) extends FixedTypedCollection {
             public function isValidType($value): bool
@@ -75,7 +80,8 @@ class FixedTypedCollectionTest extends TestCase
 
     public function testIsValidatingKeyOnGet(): void
     {
-        $object1 = new class {};
+        $object1 = new class() {
+        };
 
         $collection = new class(1, [$object1]) extends FixedTypedCollection {
             public function isValidType($value): bool
@@ -92,7 +98,7 @@ class FixedTypedCollectionTest extends TestCase
 
     public function testIsValidatingKeyOnOffsetGet(): void
     {
-        $object1 = new class {
+        $object1 = new class() {
             public $test = 'foo';
         };
 
@@ -111,7 +117,7 @@ class FixedTypedCollectionTest extends TestCase
 
     public function testIsApplyingMatchingCriteria(): void
     {
-        $object1 = new class {
+        $object1 = new class() {
             public $test = 'foo';
         };
 

--- a/tests/Type/Collection/TypedCollectionTest.php
+++ b/tests/Type/Collection/TypedCollectionTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Linio\Common\Collection;
+namespace Linio\Common\Type\Collection;
 
 class TypedCollectionTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Type/Collection/TypedCollectionTest.php
+++ b/tests/Type/Collection/TypedCollectionTest.php
@@ -10,7 +10,7 @@ class TypedCollectionTest extends \PHPUnit_Framework_TestCase
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage Unsupported type: stdClass
      */
-    public function testIsValidatingTypeOnConstruct()
+    public function testIsValidatingTypeOnConstruct(): void
     {
         $collection = $this->getMockForAbstractClass('Linio\Collection\TypedCollection');
         $collection->expects($this->at(0))
@@ -26,7 +26,7 @@ class TypedCollectionTest extends \PHPUnit_Framework_TestCase
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage Unsupported type: string
      */
-    public function testIsValidatingTypeOnOffsetSet()
+    public function testIsValidatingTypeOnOffsetSet(): void
     {
         $collection = $this->getMockForAbstractClass('Linio\Collection\TypedCollection');
         $collection->expects($this->once())
@@ -39,7 +39,7 @@ class TypedCollectionTest extends \PHPUnit_Framework_TestCase
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage Unsupported type: string
      */
-    public function testIsValidatingTypeOnAdd()
+    public function testIsValidatingTypeOnAdd(): void
     {
         $collection = $this->getMockForAbstractClass('Linio\Collection\TypedCollection');
         $collection->expects($this->once())

--- a/tests/Type/Collection/TypedCollectionTest.php
+++ b/tests/Type/Collection/TypedCollectionTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Linio\Common\Type\Collection;
 
-class TypedCollectionTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class TypedCollectionTest extends TestCase
 {
     /**
      * @expectedException \InvalidArgumentException

--- a/tests/Type/Collection/TypedCollectionTest.php
+++ b/tests/Type/Collection/TypedCollectionTest.php
@@ -4,49 +4,53 @@ declare(strict_types=1);
 
 namespace Linio\Common\Type\Collection;
 
+use DateTime;
+use DateTimeImmutable;
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
 class TypedCollectionTest extends TestCase
 {
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Unsupported type: stdClass
-     */
     public function testIsValidatingTypeOnConstruct(): void
     {
-        $collection = $this->getMockForAbstractClass('Linio\Collection\TypedCollection');
-        $collection->expects($this->at(0))
-            ->method('isValidType')
-            ->will($this->returnValue(true));
-        $collection->expects($this->at(1))
-            ->method('isValidType')
-            ->will($this->returnValue(false));
-        $collection->__construct([new \DateTime(), new \StdClass()]);
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unsupported type: DateTime');
+
+        new class([new DateTime(), new DateTimeImmutable()]) extends TypedCollection {
+            public function isValidType($value): bool
+            {
+                return $value instanceof DateTimeImmutable;
+            }
+        };
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Unsupported type: string
-     */
     public function testIsValidatingTypeOnOffsetSet(): void
     {
-        $collection = $this->getMockForAbstractClass('Linio\Collection\TypedCollection');
-        $collection->expects($this->once())
-            ->method('isValidType')
-            ->will($this->returnValue(false));
-        $collection[] = 'foobar';
+        $collection = new class([]) extends TypedCollection {
+            public function isValidType($value): bool
+            {
+                return $value instanceof DateTimeImmutable;
+            }
+        };
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unsupported type: DateTime');
+
+        $collection[] = new DateTime();
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Unsupported type: string
-     */
     public function testIsValidatingTypeOnAdd(): void
     {
-        $collection = $this->getMockForAbstractClass('Linio\Collection\TypedCollection');
-        $collection->expects($this->once())
-            ->method('isValidType')
-            ->will($this->returnValue(false));
-        $collection->add('foobar');
+        $collection = new class([]) extends TypedCollection {
+            public function isValidType($value): bool
+            {
+                return $value instanceof DateTimeImmutable;
+            }
+        };
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unsupported type: DateTime');
+
+        $collection->add(new DateTime());
     }
 }

--- a/tests/Type/DateTest.php
+++ b/tests/Type/DateTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Linio\Common\Type;
 
+use DateTime;
 use PHPUnit\Framework\TestCase;
 
 class DateTest extends TestCase
@@ -16,10 +17,10 @@ class DateTest extends TestCase
 
     public function testIsCreatingFromDateTime(): void
     {
-        $dateTime = new \DateTime('2000-01-01 09:09:09');
+        $dateTime = new DateTime('2000-01-01 09:09:09');
         $date = Date::createFromDateTime($dateTime);
 
-        $this->assertInstanceOf('Linio\Type\Date', $date);
+        $this->assertInstanceOf(Date::class, $date);
         $this->assertEquals('2000-01-01', $date->format('Y-m-d'));
     }
 }

--- a/tests/Type/DateTest.php
+++ b/tests/Type/DateTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Linio\Type;
+namespace Linio\Common\Type;
 
 class DateTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Type/DateTest.php
+++ b/tests/Type/DateTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Linio\Common\Type;
 
-class DateTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class DateTest extends TestCase
 {
     public function testIsCreatingDate(): void
     {

--- a/tests/Type/DateTest.php
+++ b/tests/Type/DateTest.php
@@ -6,13 +6,13 @@ namespace Linio\Common\Type;
 
 class DateTest extends \PHPUnit_Framework_TestCase
 {
-    public function testIsCreatingDate()
+    public function testIsCreatingDate(): void
     {
         $date = new Date('2000-01-01 09:09:09');
         $this->assertEquals('2000-01-01 00:00:00', $date->format('Y-m-d H:i:s'));
     }
 
-    public function testIsCreatingFromDateTime()
+    public function testIsCreatingFromDateTime(): void
     {
         $dateTime = new \DateTime('2000-01-01 09:09:09');
         $date = Date::createFromDateTime($dateTime);

--- a/tests/Type/DictionaryTest.php
+++ b/tests/Type/DictionaryTest.php
@@ -6,85 +6,85 @@ namespace Linio\Common\Type;
 
 class DictionaryTest extends \PHPUnit_Framework_TestCase
 {
-    public function testIsGettingKey()
+    public function testIsGettingKey(): void
     {
         $dict = new Dictionary(['foo' => 'bar']);
         $this->assertEquals('bar', $dict->get('foo'));
     }
 
-    public function testIsGettingMissingKey()
+    public function testIsGettingMissingKey(): void
     {
         $dict = new Dictionary();
         $this->assertNull($dict->get('foo'));
     }
 
-    public function testIsGettingMissingKeyWithDefaultValue()
+    public function testIsGettingMissingKeyWithDefaultValue(): void
     {
         $dict = new Dictionary();
         $this->assertEquals('default', $dict->get('foo', 'default'));
     }
 
-    public function testIsConvertingToArray()
+    public function testIsConvertingToArray(): void
     {
         $dict = new Dictionary(['foo' => 'bar']);
         $this->assertEquals(['foo' => 'bar'], $dict->toArray());
     }
 
-    public function testIsConvertingToString()
+    public function testIsConvertingToString(): void
     {
         $dict = new Dictionary(['foo' => 'bar']);
         $this->assertEquals('{"foo":"bar"}', (string) $dict);
     }
 
-    public function testIsSettingKey()
+    public function testIsSettingKey(): void
     {
         $dict = new Dictionary();
         $dict->set('foo', 'bar');
         $this->assertEquals(['foo' => 'bar'], $dict->toArray());
     }
 
-    public function testIsCheckingKey()
+    public function testIsCheckingKey(): void
     {
         $dict = new Dictionary(['foo' => 'bar']);
         $this->assertTrue($dict->has('foo'));
         $this->assertFalse($dict->has('baz'));
     }
 
-    public function testIsCheckingValue()
+    public function testIsCheckingValue(): void
     {
         $dict = new Dictionary(['foo' => 'bar']);
         $this->assertTrue($dict->contains('bar'));
         $this->assertFalse($dict->contains('baz'));
     }
 
-    public function testIsRemovingKey()
+    public function testIsRemovingKey(): void
     {
         $dict = new Dictionary(['foo' => 'bar']);
         $dict->remove('foo');
         $this->assertFalse($dict->has('foo'));
     }
 
-    public function testIsClearing()
+    public function testIsClearing(): void
     {
         $dict = new Dictionary(['foo' => 'bar']);
         $dict->clear();
         $this->assertEmpty($dict->toArray());
     }
 
-    public function testIsReplacing()
+    public function testIsReplacing(): void
     {
         $dict = new Dictionary();
         $dict->replace(['foo' => 'bar']);
         $this->assertEquals(['foo' => 'bar'], $dict->toArray());
     }
 
-    public function testIsCounting()
+    public function testIsCounting(): void
     {
         $dict = new Dictionary(['foo' => 'bar']);
         $this->assertEquals(1, $dict->count());
     }
 
-    public function testIsCheckingEmptiness()
+    public function testIsCheckingEmptiness(): void
     {
         $dict = new Dictionary();
         $this->assertTrue($dict->isEmpty());
@@ -92,13 +92,13 @@ class DictionaryTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($dict->isEmpty());
     }
 
-    public function testIsGettingAllKeys()
+    public function testIsGettingAllKeys(): void
     {
         $dict = new Dictionary(['foo' => 'bar', 'fooz' => 'baz']);
         $this->assertEquals(['foo', 'fooz'], $dict->getKeys());
     }
 
-    public function testIsEncodingToJson()
+    public function testIsEncodingToJson(): void
     {
         $dict = new Dictionary(['foo' => 'bar']);
         $this->assertEquals('{"foo":"bar"}', $dict);

--- a/tests/Type/DictionaryTest.php
+++ b/tests/Type/DictionaryTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Linio\Common\Type;
 
-class DictionaryTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class DictionaryTest extends TestCase
 {
     public function testIsGettingKey(): void
     {

--- a/tests/Type/DictionaryTest.php
+++ b/tests/Type/DictionaryTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Linio\Type;
+namespace Linio\Common\Type;
 
 class DictionaryTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Type/MoneyTest.php
+++ b/tests/Type/MoneyTest.php
@@ -6,7 +6,7 @@ namespace Linio\Common\Type;
 
 class MoneyTest extends \PHPUnit_Framework_TestCase
 {
-    public function testIsCreatingMoney()
+    public function testIsCreatingMoney(): void
     {
         $money = new Money(200);
         $this->assertEquals(200, $money->getMoneyAmount());
@@ -27,7 +27,7 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(245656, $money->getAmount());
     }
 
-    public function testIsHandlingScale()
+    public function testIsHandlingScale(): void
     {
         $money = new Money(256.73);
         $money->setScale(3);
@@ -35,7 +35,7 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(3, $money->getScale());
     }
 
-    public function testIsCreatingMoneyWithFloat()
+    public function testIsCreatingMoneyWithFloat(): void
     {
         $money = new Money(25.00);
         $this->assertEquals(25, $money->getMoneyAmount());
@@ -53,12 +53,12 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException \TypeError
      */
-    public function testIsNotCreatingMoneyWithString()
+    public function testIsNotCreatingMoneyWithString(): void
     {
         $money = new Money('test');
     }
 
-    public function testIsAddingMonies()
+    public function testIsAddingMonies(): void
     {
         $money1 = new Money(100);
         $money2 = new Money(100);
@@ -67,7 +67,7 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected->getMoneyAmount(), $result->getMoneyAmount());
     }
 
-    public function testIsSubtractingMonies()
+    public function testIsSubtractingMonies(): void
     {
         $money1 = new Money(200);
         $money2 = new Money(100);
@@ -82,7 +82,7 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected->getMoneyAmount(), $result->getMoneyAmount());
     }
 
-    public function testIsMultiplyingMonies()
+    public function testIsMultiplyingMonies(): void
     {
         $money = new Money(1);
         $expected = new Money(2);
@@ -102,7 +102,7 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected->getMoneyAmount(), $result->getMoneyAmount());
     }
 
-    public function testIsDividingMonies()
+    public function testIsDividingMonies(): void
     {
         $money = new Money(10);
         $expected = new Money(5);
@@ -113,7 +113,7 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected->getMoneyAmount(), $money->divide(3)->getMoneyAmount());
     }
 
-    public function testIsCalculatingPercentage()
+    public function testIsCalculatingPercentage(): void
     {
         $money = new Money(100);
         $expected = new Money(8);
@@ -145,7 +145,7 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($total->getMoneyAmount(), $money->applyPercentage(0.0041)->getMoneyAmount());
     }
 
-    public function testIsCalculatingInterestRate()
+    public function testIsCalculatingInterestRate(): void
     {
         $money = new Money(100);
         $expected = new Money(9.99);
@@ -156,7 +156,7 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($total->getMoneyAmount(), $money->applyInterest(0.333, 30)->getMoneyAmount());
     }
 
-    public function testIsComparingMonies()
+    public function testIsComparingMonies(): void
     {
         $money1 = new Money(1);
         $money2 = new Money(2);
@@ -169,7 +169,7 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($money2->equals(new \stdClass()));
     }
 
-    public function testIsCheckingMonies()
+    public function testIsCheckingMonies(): void
     {
         $this->assertTrue((new Money(0))->isZero());
         $this->assertTrue((new Money(-1))->isNegative());
@@ -179,7 +179,7 @@ class MoneyTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse((new Money(-1))->isPositive());
     }
 
-    public function testIsConvertingToString()
+    public function testIsConvertingToString(): void
     {
         $money = new Money(457.98);
         $this->assertEquals('45798', (string) $money);

--- a/tests/Type/MoneyTest.php
+++ b/tests/Type/MoneyTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Linio\Common\Type;
 
 use PHPUnit\Framework\TestCase;
+use TypeError;
 
 class MoneyTest extends TestCase
 {
@@ -52,12 +53,10 @@ class MoneyTest extends TestCase
         $this->assertEquals(18213.24, $money->getMoneyAmount());
     }
 
-    /**
-     * @expectedException \TypeError
-     */
     public function testIsNotCreatingMoneyWithString(): void
     {
-        $money = new Money('test');
+        $this->expectException(TypeError::class);
+        new Money('test');
     }
 
     public function testIsAddingMonies(): void

--- a/tests/Type/MoneyTest.php
+++ b/tests/Type/MoneyTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Linio\Common\Type;
 
-class MoneyTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class MoneyTest extends TestCase
 {
     public function testIsCreatingMoney(): void
     {

--- a/tests/Type/MoneyTest.php
+++ b/tests/Type/MoneyTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Linio\Type;
+namespace Linio\Common\Type;
 
 class MoneyTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Type/PreciseMoneyTest.php
+++ b/tests/Type/PreciseMoneyTest.php
@@ -6,7 +6,7 @@ namespace Linio\Common\Type;
 
 class PreciseMoneyTest extends \PHPUnit_Framework_TestCase
 {
-    public function testIsCreatingMoney()
+    public function testIsCreatingMoney(): void
     {
         $money = new PreciseMoney(200);
         $this->assertEquals(200, $money->getMoneyAmount());
@@ -27,7 +27,7 @@ class PreciseMoneyTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(245656, $money->getAmount());
     }
 
-    public function testIsHandlingScale()
+    public function testIsHandlingScale(): void
     {
         $money = new PreciseMoney(256.73);
         $money->setScale(3);
@@ -35,7 +35,7 @@ class PreciseMoneyTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(3, $money->getScale());
     }
 
-    public function testIsCreatingMoneyWithFloat()
+    public function testIsCreatingMoneyWithFloat(): void
     {
         $money = new PreciseMoney(25.00);
         $this->assertEquals(25, $money->getMoneyAmount());
@@ -53,12 +53,12 @@ class PreciseMoneyTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException \TypeError
      */
-    public function testIsNotCreatingMoneyWithString()
+    public function testIsNotCreatingMoneyWithString(): void
     {
         $money = new PreciseMoney('test');
     }
 
-    public function testIsAddingMonies()
+    public function testIsAddingMonies(): void
     {
         $money1 = new PreciseMoney(100);
         $money2 = new PreciseMoney(100);
@@ -67,7 +67,7 @@ class PreciseMoneyTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected->getMoneyAmount(), $result->getMoneyAmount());
     }
 
-    public function testIsSubtractingMonies()
+    public function testIsSubtractingMonies(): void
     {
         $money1 = new PreciseMoney(200);
         $money2 = new PreciseMoney(100);
@@ -82,7 +82,7 @@ class PreciseMoneyTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected->getMoneyAmount(), $result->getMoneyAmount());
     }
 
-    public function testIsMultiplyingMonies()
+    public function testIsMultiplyingMonies(): void
     {
         $money = new PreciseMoney(1);
         $expected = new PreciseMoney(2);
@@ -102,7 +102,7 @@ class PreciseMoneyTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected->getMoneyAmount(), $result->getMoneyAmount());
     }
 
-    public function testIsDividingMonies()
+    public function testIsDividingMonies(): void
     {
         $money = new PreciseMoney(10);
         $expected = new PreciseMoney(5);
@@ -113,7 +113,7 @@ class PreciseMoneyTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected->getMoneyAmount(), $money->divide(3)->getMoneyAmount());
     }
 
-    public function testIsCalculatingPercentage()
+    public function testIsCalculatingPercentage(): void
     {
         $money = new PreciseMoney(100);
         $expected = new PreciseMoney(8);
@@ -145,7 +145,7 @@ class PreciseMoneyTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($total->getMoneyAmount(), $money->applyPercentage(0.0041)->getMoneyAmount());
     }
 
-    public function testIsCalculatingInterestRate()
+    public function testIsCalculatingInterestRate(): void
     {
         $money = new PreciseMoney(100);
         $expected = new PreciseMoney(9.99);
@@ -156,7 +156,7 @@ class PreciseMoneyTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($total->getMoneyAmount(), $money->applyInterest(0.333, 30)->getMoneyAmount());
     }
 
-    public function testIsComparingMonies()
+    public function testIsComparingMonies(): void
     {
         $money1 = new PreciseMoney(1);
         $money2 = new PreciseMoney(2);
@@ -169,7 +169,7 @@ class PreciseMoneyTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($money2->equals(new \stdClass()));
     }
 
-    public function testIsCheckingMonies()
+    public function testIsCheckingMonies(): void
     {
         $this->assertTrue((new PreciseMoney(0))->isZero());
         $this->assertTrue((new PreciseMoney(-1))->isNegative());
@@ -179,7 +179,7 @@ class PreciseMoneyTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse((new PreciseMoney(-1))->isPositive());
     }
 
-    public function testIsConvertingToString()
+    public function testIsConvertingToString(): void
     {
         $money = new PreciseMoney(457.98);
         $this->assertEquals('45798', (string) $money);

--- a/tests/Type/PreciseMoneyTest.php
+++ b/tests/Type/PreciseMoneyTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Linio\Common\Type;
 
 use PHPUnit\Framework\TestCase;
+use TypeError;
 
 class PreciseMoneyTest extends TestCase
 {
@@ -52,12 +53,10 @@ class PreciseMoneyTest extends TestCase
         $this->assertEquals(18213.24, $money->getMoneyAmount());
     }
 
-    /**
-     * @expectedException \TypeError
-     */
     public function testIsNotCreatingMoneyWithString(): void
     {
-        $money = new PreciseMoney('test');
+        $this->expectException(TypeError::class);
+        new PreciseMoney('test');
     }
 
     public function testIsAddingMonies(): void

--- a/tests/Type/PreciseMoneyTest.php
+++ b/tests/Type/PreciseMoneyTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Linio\Common\Type;
 
-class PreciseMoneyTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class PreciseMoneyTest extends TestCase
 {
     public function testIsCreatingMoney(): void
     {

--- a/tests/Type/PreciseMoneyTest.php
+++ b/tests/Type/PreciseMoneyTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Linio\Type;
+namespace Linio\Common\Type;
 
 class PreciseMoneyTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/Type/TimeTest.php
+++ b/tests/Type/TimeTest.php
@@ -20,7 +20,7 @@ class TimeTest extends TestCase
         $dateTime = new DateTime('2000-01-01 09:09:09');
         $time = Time::createFromDateTime($dateTime);
 
-        $this->assertInstanceOf('Linio\Type\Time', $time);
+        $this->assertInstanceOf(Time::class, $time);
         $this->assertEquals('09:09:09', $time->format('H:i:s'));
     }
 }

--- a/tests/Type/TimeTest.php
+++ b/tests/Type/TimeTest.php
@@ -6,13 +6,13 @@ namespace Linio\Common\Type;
 
 class TimeTest extends \PHPUnit_Framework_TestCase
 {
-    public function testIsCreatingTime()
+    public function testIsCreatingTime(): void
     {
         $date = new Time('2014-01-22 09:09:09');
         $this->assertEquals('1970-01-01 09:09:09', $date->format('Y-m-d H:i:s'));
     }
 
-    public function testIsCreatingFromDateTime()
+    public function testIsCreatingFromDateTime(): void
     {
         $dateTime = new \DateTime('2000-01-01 09:09:09');
         $time = Time::createFromDateTime($dateTime);

--- a/tests/Type/TimeTest.php
+++ b/tests/Type/TimeTest.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace Linio\Common\Type;
 
-class TimeTest extends \PHPUnit_Framework_TestCase
+use DateTime;
+use PHPUnit\Framework\TestCase;
+
+class TimeTest extends TestCase
 {
     public function testIsCreatingTime(): void
     {
@@ -14,7 +17,7 @@ class TimeTest extends \PHPUnit_Framework_TestCase
 
     public function testIsCreatingFromDateTime(): void
     {
-        $dateTime = new \DateTime('2000-01-01 09:09:09');
+        $dateTime = new DateTime('2000-01-01 09:09:09');
         $time = Time::createFromDateTime($dateTime);
 
         $this->assertInstanceOf('Linio\Type\Time', $time);

--- a/tests/Type/TimeTest.php
+++ b/tests/Type/TimeTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Linio\Type;
+namespace Linio\Common\Type;
 
 class TimeTest extends \PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
* Changed namespace to Linio\Common
* Moved Collections under Type namespaces as they are a type.
* Updated php-cs-fixer's ruleset to new rules.
* Upgraded to PHPUnit 6.0
* Refactored tests
* Added forwardsCompatibility layer to allow people to continue to upgrade without a ton of work with the namespace changes at the moment.

Questions:

* Should the compatibility layer be renamed to backwardsCompatibility (I followed PHPUnit's lead on this)?
* Should we even have the compatibility layer?
* Should the compatibility layer be moved to another package instead?