### PR TITLE
Added new base exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Linio Common contains small components that either extend PHP's functionality or
 a coherent base for Linio components:
 
 * Common & Collection Types
+* Base exceptions
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ a coherent base for Linio components:
 
 * Common & Collection Types
 * Base exceptions
+* Monolog processors and handlers
 
 ## Install
 
@@ -71,3 +72,91 @@ class UserCollection extends TypedCollection
     }
 }
 ```
+
+## Exceptions
+
+These exceptions provide a good base for all domain exceptions. The included interfaces act as tags that
+allow the Monolog processors and handlers to interact with them in specified ways.
+
+#### DomainException
+
+This exception is the core exception in which all other library and application (domain) exceptions should
+extend. It's used by the exception handlers included in our common libraries for different frameworks.
+With this, we can easily support translation of messages, and input errors on a per field basis.
+
+```php
+<?php
+
+throw new \Linio\Common\Exception\DomainException(
+    'ORDER_COULD_NOT_BE_PROCESSED', 
+    500, 
+    'The order could not be processed because the processor is not responding'
+);
+``` 
+
+#### ClientException
+
+```php
+<?php
+
+throw new \Linio\Common\Exception\ClientException(
+    'ORDER_INCOMPLETE', 
+    400, 
+    'The order could not be processed because the request is incomplete'
+);
+``` 
+
+#### EntityNotFoundException
+
+```php
+<?php
+
+throw new \Linio\Common\Exception\EntityNotFoundException(
+    'Customer',
+    'b3ed5dec-a152-4f38-8726-4c4628a6fdbd'
+);
+``` 
+
+```php
+<?php
+
+throw new \Linio\Common\Exception\EntityNotFoundException(
+    'Postcode',
+    ['region' => 'Region 1', 'municipality' => 'Municipality 1']
+);
+```
+
+```php
+<?php
+
+class CustomerNotFoundException extends \Linio\Common\Exception\EntityNotFoundException
+{
+    public function __construct(string $identifier)
+    {
+        parent::__construct('Customer', $identifier, 'CUSTOMER_NOT_FOUND');
+    }
+}
+```
+
+### Interfaces
+
+The available interfaces are:
+
+* `Linio\Common\Exception\DoNotLog` - Tells Monolog to ignore the exception
+* `Linio\Common\Exception\ForceLogging` - Tells Monolog to log the exception regardless of `DoNotLog`
+* `Linio\Common\Exception\CriticalError` - Tells Monolog to log the exception as `CRITICAL` regardless of it's current level
+
+## Logging (Monolog)
+
+This component includes various classes that integrate with Monolog.
+
+### Processors
+
+* `Linio\Common\Logging\CriticalErrorProcessor` - Upgrades exceptions that are CriticalErrors to CRITICAL regardless of log level.
+* `Linio\Common\Logging\ExceptionTokenProcessor` - Adds the exception token to the record.
+
+### Handlers
+
+#### DoNotLogHandler
+
+* `Linio\Common\Logging\DoNotLogHandler` - Ignores exceptions that implement this interface.

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0",
-        "friendsofphp/php-cs-fixer": "^2.4"
+        "friendsofphp/php-cs-fixer": "^2.4",
+        "monolog/monolog": "^1.23"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -23,5 +23,11 @@
         "psr-4": {
             "Linio\\Common\\": "tests/"
         }
+    },
+    "scripts": {
+        "test": [
+            "phpunit",
+            "php-cs-fixer fix --dry-run"
+        ]
     }
 }

--- a/src/Exception/ClientException.php
+++ b/src/Exception/ClientException.php
@@ -13,7 +13,7 @@ class ClientException extends DomainException implements DoNotLog
     public function __construct(
         string $token,
         int $statusCode = self::DEFAULT_STATUS_CODE,
-        string $message = '',
+        string $message = ExceptionTokens::INVALID_REQUEST,
         array $errors = [],
         Throwable $previous = null
     ) {

--- a/src/Exception/ClientException.php
+++ b/src/Exception/ClientException.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Linio\Common\Exception;
+
+use Throwable;
+
+class ClientException extends DomainException implements DoNotLog
+{
+    public const DEFAULT_STATUS_CODE = 400;
+
+    public function __construct(
+        string $token,
+        string $message = ExceptionTokens::INVALID_REQUEST,
+        int $statusCode = self::DEFAULT_STATUS_CODE,
+        array $errors = [],
+        Throwable $previous = null
+    ) {
+        parent::__construct($token, $message, $statusCode, $errors, $previous);
+    }
+}

--- a/src/Exception/ClientException.php
+++ b/src/Exception/ClientException.php
@@ -13,10 +13,10 @@ class ClientException extends DomainException implements DoNotLog
     public function __construct(
         string $token,
         int $statusCode = self::DEFAULT_STATUS_CODE,
-        ?string $internalDetail = null,
+        string $message = '',
         array $errors = [],
         Throwable $previous = null
     ) {
-        parent::__construct($token, $statusCode, $internalDetail, $errors, $previous);
+        parent::__construct($token, $statusCode, $message, $errors, $previous);
     }
 }

--- a/src/Exception/ClientException.php
+++ b/src/Exception/ClientException.php
@@ -12,11 +12,11 @@ class ClientException extends DomainException implements DoNotLog
 
     public function __construct(
         string $token,
-        string $message = ExceptionTokens::INVALID_REQUEST,
         int $statusCode = self::DEFAULT_STATUS_CODE,
+        ?string $internalDetail = null,
         array $errors = [],
         Throwable $previous = null
     ) {
-        parent::__construct($token, $message, $statusCode, $errors, $previous);
+        parent::__construct($token, $statusCode, $internalDetail, $errors, $previous);
     }
 }

--- a/src/Exception/CriticalError.php
+++ b/src/Exception/CriticalError.php
@@ -7,6 +7,6 @@ namespace Linio\Common\Exception;
 /**
  * This exception will be logged as a critical error in Monolog.
  */
-class CriticalException extends DomainException
+interface CriticalError
 {
 }

--- a/src/Exception/CriticalException.php
+++ b/src/Exception/CriticalException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Linio\Common\Exception;
+
+/*
+ * This exception will be logged as a critical error in Monolog.
+ */
+class CriticalException extends DomainException
+{
+}

--- a/src/Exception/CriticalException.php
+++ b/src/Exception/CriticalException.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Linio\Common\Exception;
 
-/*
+/**
  * This exception will be logged as a critical error in Monolog.
  */
 class CriticalException extends DomainException

--- a/src/Exception/DoNotLog.php
+++ b/src/Exception/DoNotLog.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Linio\Common\Exception;
+
+/*
+ * Makes the Monolog Handler ignore the exception and bypass logging.
+ */
+interface DoNotLog
+{
+}

--- a/src/Exception/DoNotLog.php
+++ b/src/Exception/DoNotLog.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Linio\Common\Exception;
 
-/*
+/**
  * Makes the Monolog Handler ignore the exception and bypass logging.
  */
 interface DoNotLog

--- a/src/Exception/DomainException.php
+++ b/src/Exception/DomainException.php
@@ -12,9 +12,9 @@ class DomainException extends SplDomainException
     public const DEFAULT_STATUS_CODE = 500;
 
     /**
-     * @var string|null
+     * @var string
      */
-    private $internalDetail;
+    private $token;
 
     /**
      * @var Error[]
@@ -24,19 +24,19 @@ class DomainException extends SplDomainException
     public function __construct(
         string $token,
         int $statusCode = self::DEFAULT_STATUS_CODE,
-        ?string $internalDetail = null,
+        string $message = '',
         array $errors = [],
         Throwable $previous = null
     ) {
-        $this->internalDetail = $internalDetail;
+        $this->token = $token;
         $this->errors = $errors;
 
-        parent::__construct($token, $statusCode, $previous);
+        parent::__construct($message, $statusCode, $previous);
     }
 
-    public function getInternalDetail(): ?string
+    public function getToken(): string
     {
-        return $this->internalDetail;
+        return $this->token;
     }
 
     public function getErrors(): array

--- a/src/Exception/DomainException.php
+++ b/src/Exception/DomainException.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Linio\Common\Exception;
 
 use DomainException as SplDomainException;
+use InvalidArgumentException;
 use Throwable;
 
 class DomainException extends SplDomainException
@@ -28,6 +29,10 @@ class DomainException extends SplDomainException
         array $errors = [],
         Throwable $previous = null
     ) {
+        if (!$this->isExceptionToken($token)) {
+            throw new InvalidArgumentException(ExceptionTokens::INVALID_EXCEPTION_TOKEN, 500);
+        }
+
         $this->token = $token;
         $this->errors = $errors;
 
@@ -42,5 +47,10 @@ class DomainException extends SplDomainException
     public function getErrors(): array
     {
         return $this->errors;
+    }
+
+    private function isExceptionToken(string $token): bool
+    {
+        return preg_match('/[A-Z][A-Z_]/', $token) === 1;
     }
 }

--- a/src/Exception/DomainException.php
+++ b/src/Exception/DomainException.php
@@ -25,7 +25,7 @@ class DomainException extends SplDomainException
     public function __construct(
         string $token,
         int $statusCode = self::DEFAULT_STATUS_CODE,
-        string $message = '',
+        string $message = ExceptionTokens::AN_ERROR_HAS_OCCURRED,
         array $errors = [],
         Throwable $previous = null
     ) {

--- a/src/Exception/DomainException.php
+++ b/src/Exception/DomainException.php
@@ -12,9 +12,9 @@ class DomainException extends SplDomainException
     public const DEFAULT_STATUS_CODE = 500;
 
     /**
-     * @var string
+     * @var string|null
      */
-    private $token;
+    private $internalDetail;
 
     /**
      * @var Error[]
@@ -23,20 +23,20 @@ class DomainException extends SplDomainException
 
     public function __construct(
         string $token,
-        string $message = ExceptionTokens::AN_ERROR_HAS_OCCURRED,
         int $statusCode = self::DEFAULT_STATUS_CODE,
+        ?string $internalDetail = null,
         array $errors = [],
         Throwable $previous = null
     ) {
-        $this->token = $token;
+        $this->internalDetail = $internalDetail;
         $this->errors = $errors;
 
-        parent::__construct($message, $statusCode, $previous);
+        parent::__construct($token, $statusCode, $previous);
     }
 
-    public function getToken(): string
+    public function getInternalDetail(): ?string
     {
-        return $this->token;
+        return $this->internalDetail;
     }
 
     public function getErrors(): array

--- a/src/Exception/DomainException.php
+++ b/src/Exception/DomainException.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Linio\Common\Exception;
+
+use DomainException as SplDomainException;
+use Throwable;
+
+class DomainException extends SplDomainException
+{
+    public const DEFAULT_STATUS_CODE = 500;
+
+    /**
+     * @var string
+     */
+    private $token;
+
+    /**
+     * @var Error[]
+     */
+    private $errors = [];
+
+    public function __construct(
+        string $token,
+        string $message = ExceptionTokens::AN_ERROR_HAS_OCCURRED,
+        int $statusCode = self::DEFAULT_STATUS_CODE,
+        array $errors = [],
+        Throwable $previous = null
+    ) {
+        $this->token = $token;
+        $this->errors = $errors;
+
+        parent::__construct($message, $statusCode, $previous);
+    }
+
+    public function getToken(): string
+    {
+        return $this->token;
+    }
+
+    public function getErrors(): array
+    {
+        return $this->errors;
+    }
+}

--- a/src/Exception/DomainException.php
+++ b/src/Exception/DomainException.php
@@ -51,6 +51,6 @@ class DomainException extends SplDomainException
 
     private function isExceptionToken(string $token): bool
     {
-        return preg_match('/[A-Z][A-Z_]/', $token) === 1;
+        return preg_match('/^[A-Z][A-Z_]*[A-Z]$/', $token) === 1;
     }
 }

--- a/src/Exception/EntityNotFoundException.php
+++ b/src/Exception/EntityNotFoundException.php
@@ -10,13 +10,34 @@ class EntityNotFoundException extends ClientException
 {
     public const DEFAULT_STATUS_CODE = 404;
 
+    /**
+     * @param string $entity The entity that could not be found, for example "Telesales Agent"
+     * @param string|array $identifier The id of the entity that could not be found.
+     *                                 For example "test@example.com" or
+     *                                 ['region' => 'Region 1', 'municipality' => 'Municipality 1']
+     */
     public function __construct(
-        string $message = ExceptionTokens::ENTITY_NOT_FOUND,
+        string $entity,
+        $identifier,
         string $token = ExceptionTokens::ENTITY_NOT_FOUND,
         int $statusCode = self::DEFAULT_STATUS_CODE,
         array $errors = [],
         Throwable $previous = null
     ) {
+        $formattedIdentifier = $this->getIdentifier($identifier);
+        $message = sprintf('Could not find [%s] identified by %s!', $entity, $formattedIdentifier);
+
         parent::__construct($token, $statusCode, $message, $errors, $previous);
+    }
+
+    private function getIdentifier($identifiers)
+    {
+        if (is_array($identifiers)) {
+            return implode(', ', array_map(function (string $value, string $key) {
+                return sprintf('[%s] = [%s]', $key, $value);
+            }, $identifiers, array_keys($identifiers)));
+        }
+
+        return sprintf('[%s]', $identifiers);
     }
 }

--- a/src/Exception/EntityNotFoundException.php
+++ b/src/Exception/EntityNotFoundException.php
@@ -10,11 +10,11 @@ class EntityNotFoundException extends ClientException
 {
     public function __construct(
         string $token = ExceptionTokens::ENTITY_NOT_FOUND,
-        string $message = ExceptionTokens::ENTITY_NOT_FOUND,
         int $statusCode = self::DEFAULT_STATUS_CODE,
+        ?string $internalDetail = null,
         array $errors = [],
         Throwable $previous = null
     ) {
-        parent::__construct($token, $message, $statusCode, $errors, $previous);
+        parent::__construct($token, $statusCode, $internalDetail, $errors, $previous);
     }
 }

--- a/src/Exception/EntityNotFoundException.php
+++ b/src/Exception/EntityNotFoundException.php
@@ -11,10 +11,10 @@ class EntityNotFoundException extends ClientException
     public function __construct(
         string $token = ExceptionTokens::ENTITY_NOT_FOUND,
         int $statusCode = self::DEFAULT_STATUS_CODE,
-        ?string $internalDetail = null,
+        string $message = '',
         array $errors = [],
         Throwable $previous = null
     ) {
-        parent::__construct($token, $statusCode, $internalDetail, $errors, $previous);
+        parent::__construct($token, $statusCode, $message, $errors, $previous);
     }
 }

--- a/src/Exception/EntityNotFoundException.php
+++ b/src/Exception/EntityNotFoundException.php
@@ -11,7 +11,7 @@ class EntityNotFoundException extends ClientException
     public const DEFAULT_STATUS_CODE = 404;
 
     public function __construct(
-        string $message = '',
+        string $message = ExceptionTokens::ENTITY_NOT_FOUND,
         string $token = ExceptionTokens::ENTITY_NOT_FOUND,
         int $statusCode = self::DEFAULT_STATUS_CODE,
         array $errors = [],

--- a/src/Exception/EntityNotFoundException.php
+++ b/src/Exception/EntityNotFoundException.php
@@ -8,6 +8,8 @@ use Throwable;
 
 class EntityNotFoundException extends ClientException
 {
+    public const DEFAULT_STATUS_CODE = 404;
+
     public function __construct(
         string $token = ExceptionTokens::ENTITY_NOT_FOUND,
         int $statusCode = self::DEFAULT_STATUS_CODE,

--- a/src/Exception/EntityNotFoundException.php
+++ b/src/Exception/EntityNotFoundException.php
@@ -11,9 +11,9 @@ class EntityNotFoundException extends ClientException
     public const DEFAULT_STATUS_CODE = 404;
 
     public function __construct(
+        string $message = '',
         string $token = ExceptionTokens::ENTITY_NOT_FOUND,
         int $statusCode = self::DEFAULT_STATUS_CODE,
-        string $message = '',
         array $errors = [],
         Throwable $previous = null
     ) {

--- a/src/Exception/EntityNotFoundException.php
+++ b/src/Exception/EntityNotFoundException.php
@@ -30,7 +30,7 @@ class EntityNotFoundException extends ClientException
         parent::__construct($token, $statusCode, $message, $errors, $previous);
     }
 
-    private function getIdentifier($identifiers)
+    protected function getIdentifier($identifiers): string
     {
         if (is_array($identifiers)) {
             return implode(', ', array_map(function (string $value, string $key) {

--- a/src/Exception/EntityNotFoundException.php
+++ b/src/Exception/EntityNotFoundException.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Linio\Common\Exception;
+
+use Throwable;
+
+class EntityNotFoundException extends ClientException
+{
+    public function __construct(
+        string $token = ExceptionTokens::ENTITY_NOT_FOUND,
+        string $message = ExceptionTokens::ENTITY_NOT_FOUND,
+        int $statusCode = self::DEFAULT_STATUS_CODE,
+        array $errors = [],
+        Throwable $previous = null
+    ) {
+        parent::__construct($token, $message, $statusCode, $errors, $previous);
+    }
+}

--- a/src/Exception/Error.php
+++ b/src/Exception/Error.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Linio\Common\Exception;
+
+class Error
+{
+    /**
+     * @var string
+     */
+    protected $message;
+
+    /**
+     * @var string|null
+     */
+    protected $field;
+
+    /**
+     * @param string $message Any text string is valid, however, TOKENS are recommended to support translation.
+     * @param null|string $field
+     */
+    public function __construct(string $message, ?string $field = null)
+    {
+        $this->field = $field;
+        $this->message = $message;
+    }
+
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+
+    public function getField(): string
+    {
+        return $this->field;
+    }
+}

--- a/src/Exception/Error.php
+++ b/src/Exception/Error.php
@@ -17,7 +17,7 @@ class Error
     protected $field;
 
     /**
-     * @param string $message Any text string is valid, however, TOKENS are recommended to support translation.
+     * @param string $message any text string is valid, however, TOKENS are recommended to support translation
      * @param null|string $field
      */
     public function __construct(string $message, ?string $field = null)

--- a/src/Exception/ExceptionTokens.php
+++ b/src/Exception/ExceptionTokens.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Linio\Common\Exception;
+
+class ExceptionTokens
+{
+    public const ENTITY_NOT_FOUND = 'ENTITY_NOT_FOUND';
+    public const AN_ERROR_HAS_OCCURRED = 'AN_ERROR_HAS_OCCURRED';
+    public const INVALID_REQUEST = 'INVALID_REQUEST';
+}

--- a/src/Exception/ExceptionTokens.php
+++ b/src/Exception/ExceptionTokens.php
@@ -9,4 +9,5 @@ class ExceptionTokens
     public const ENTITY_NOT_FOUND = 'ENTITY_NOT_FOUND';
     public const AN_ERROR_HAS_OCCURRED = 'AN_ERROR_HAS_OCCURRED';
     public const INVALID_REQUEST = 'INVALID_REQUEST';
+    public const INVALID_EXCEPTION_TOKEN = 'INVALID_EXCEPTION_TOKEN';
 }

--- a/src/Exception/ForceLogging.php
+++ b/src/Exception/ForceLogging.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Linio\Common\Exception;
+
+/*
+ * Makes the Monolog Handler ignore the DoNotLog interface.
+ */
+interface ForceLogging
+{
+}

--- a/src/Exception/ForceLogging.php
+++ b/src/Exception/ForceLogging.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Linio\Common\Exception;
 
-/*
+/**
  * Makes the Monolog Handler ignore the DoNotLog interface.
  */
 interface ForceLogging

--- a/src/Logging/CriticalErrorProcessor.php
+++ b/src/Logging/CriticalErrorProcessor.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Linio\Common\Logging;
 
 use Linio\Common\Exception\CriticalError;
+use Monolog\Logger;
+use Psr\Log\LogLevel;
 
 class CriticalErrorProcessor
 {
@@ -16,9 +18,8 @@ class CriticalErrorProcessor
             return $record;
         }
 
-        // Monolog doesn't use psr\log\LogLevel values internally
-        $record['level'] = 500;
-        $record['levelName'] = 'CRITICAL';
+        $record['level'] = Logger::toMonologLevel(LogLevel::CRITICAL);
+        $record['levelName'] = Logger::getLevelName($record['level']);
 
         return $record;
     }

--- a/src/Logging/CriticalErrorProcessor.php
+++ b/src/Logging/CriticalErrorProcessor.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Linio\Common\Logging;
+
+use Linio\Common\Exception\CriticalError;
+
+class CriticalErrorProcessor
+{
+    public function __invoke(array $record): array
+    {
+        $exception = $record['context']['exception'] ?? null;
+
+        if (!$exception instanceof CriticalError) {
+            return $record;
+        }
+
+        // Monolog doesn't use psr\log\LogLevel values internally
+        $record['level'] = 500;
+        $record['levelName'] = 'CRITICAL';
+
+        return $record;
+    }
+}

--- a/src/Logging/DoNotLogHandler.php
+++ b/src/Logging/DoNotLogHandler.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Linio\Common\Logging;
+
+use Linio\Common\Exception\DoNotLog;
+use Linio\Common\Exception\ForceLogging;
+use Monolog\Handler\AbstractHandler;
+
+class DoNotLogHandler extends AbstractHandler
+{
+    /**
+     * Handles a record.
+     *
+     * All records may be passed to this method, and the handler should discard
+     * those that it does not want to handle.
+     *
+     * The return value of this function controls the bubbling process of the handler stack.
+     * Unless the bubbling is interrupted (by returning true), the Logger class will keep on
+     * calling further handlers in the stack with a given log record.
+     *
+     * @param  array $record The record to handle
+     * @return Boolean true means that this handler handled the record, and that bubbling is not permitted.
+     *                        false means the record was either not processed or that this handler allows bubbling.
+     */
+    public function handle(array $record)
+    {
+        $exception = $record['context']['exception'] ?? null;
+
+        return $exception instanceof DoNotLog && !$exception instanceof ForceLogging;
+    }
+}

--- a/src/Logging/DoNotLogHandler.php
+++ b/src/Logging/DoNotLogHandler.php
@@ -21,7 +21,8 @@ class DoNotLogHandler extends AbstractHandler
      * calling further handlers in the stack with a given log record.
      *
      * @param  array $record The record to handle
-     * @return Boolean true means that this handler handled the record, and that bubbling is not permitted.
+     *
+     * @return bool true means that this handler handled the record, and that bubbling is not permitted.
      *                        false means the record was either not processed or that this handler allows bubbling.
      */
     public function handle(array $record)

--- a/src/Logging/ExceptionTokenProcessor.php
+++ b/src/Logging/ExceptionTokenProcessor.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Linio\Common\Logging;
+
+use Linio\Common\Exception\DomainException;
+
+class ExceptionTokenProcessor
+{
+    public function __invoke(array $record): array
+    {
+        $exception = $record['context']['exception'] ?? null;
+
+        if (!$exception instanceof DomainException) {
+            return $record;
+        }
+
+        $record = ['token' => $exception->getToken()] + $record;
+
+        return $record;
+    }
+}

--- a/src/Logging/ExceptionTokenProcessor.php
+++ b/src/Logging/ExceptionTokenProcessor.php
@@ -11,12 +11,13 @@ class ExceptionTokenProcessor
     public function __invoke(array $record): array
     {
         $exception = $record['context']['exception'] ?? null;
+        $token = null;
 
-        if (!$exception instanceof DomainException) {
-            return $record;
+        if ($exception instanceof DomainException) {
+            $token = $exception->getToken();
         }
 
-        $record = ['token' => $exception->getToken()] + $record;
+        $record = ['token' => $token] + $record;
 
         return $record;
     }

--- a/tests/Exception/DomainExceptionTest.php
+++ b/tests/Exception/DomainExceptionTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Linio\Common\Exception;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+class DomainExceptionTest extends TestCase
+{
+    public function testItValidatesExceptionTokens()
+    {
+        try {
+            throw new DomainException('invalid');
+        } catch (InvalidArgumentException $exception) {
+            $this->assertSame(ExceptionTokens::INVALID_EXCEPTION_TOKEN, $exception->getMessage());
+            $this->assertSame(500, $exception->getCode());
+        }
+    }
+}

--- a/tests/Exception/DomainExceptionTest.php
+++ b/tests/Exception/DomainExceptionTest.php
@@ -9,10 +9,30 @@ use PHPUnit\Framework\TestCase;
 
 class DomainExceptionTest extends TestCase
 {
-    public function testItValidatesExceptionTokens(): void
+    public function testItDoesNotAllowTokensThatAreNotUpperSnakeCase(): void
     {
         try {
             throw new DomainException('invalid');
+        } catch (InvalidArgumentException $exception) {
+            $this->assertSame(ExceptionTokens::INVALID_EXCEPTION_TOKEN, $exception->getMessage());
+            $this->assertSame(500, $exception->getCode());
+        }
+    }
+
+    public function testItDoesNotAllowTokensThatAreASingleLetter(): void
+    {
+        try {
+            throw new DomainException('A');
+        } catch (InvalidArgumentException $exception) {
+            $this->assertSame(ExceptionTokens::INVALID_EXCEPTION_TOKEN, $exception->getMessage());
+            $this->assertSame(500, $exception->getCode());
+        }
+    }
+
+    public function testItDoesNotAllowTokensThatEndInAnUnderscore(): void
+    {
+        try {
+            throw new DomainException('A_');
         } catch (InvalidArgumentException $exception) {
             $this->assertSame(ExceptionTokens::INVALID_EXCEPTION_TOKEN, $exception->getMessage());
             $this->assertSame(500, $exception->getCode());

--- a/tests/Exception/DomainExceptionTest.php
+++ b/tests/Exception/DomainExceptionTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 class DomainExceptionTest extends TestCase
 {
-    public function testItValidatesExceptionTokens()
+    public function testItValidatesExceptionTokens(): void
     {
         try {
             throw new DomainException('invalid');

--- a/tests/Exception/EntityNotFoundExceptionTest.php
+++ b/tests/Exception/EntityNotFoundExceptionTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Linio\Common\Exception;
+
+use PHPUnit\Framework\TestCase;
+
+class EntityNotFoundExceptionTest extends TestCase
+{
+    public function testItSupportsMultipleIdentifiers()
+    {
+        $exception = new EntityNotFoundException('Postcode', [
+            'region' => 'Region 1', 'municipality' => 'Municipality 1'
+        ]);
+
+        $this->assertSame(
+            'Could not find [Postcode] identified by [region] = [Region 1], [municipality] = [Municipality 1]!',
+            $exception->getMessage()
+        );
+    }
+}

--- a/tests/Exception/EntityNotFoundExceptionTest.php
+++ b/tests/Exception/EntityNotFoundExceptionTest.php
@@ -8,10 +8,10 @@ use PHPUnit\Framework\TestCase;
 
 class EntityNotFoundExceptionTest extends TestCase
 {
-    public function testItSupportsMultipleIdentifiers()
+    public function testItSupportsMultipleIdentifiers(): void
     {
         $exception = new EntityNotFoundException('Postcode', [
-            'region' => 'Region 1', 'municipality' => 'Municipality 1'
+            'region' => 'Region 1', 'municipality' => 'Municipality 1',
         ]);
 
         $this->assertSame(

--- a/tests/Logging/CriticalErrorProcessorTest.php
+++ b/tests/Logging/CriticalErrorProcessorTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Linio\Common\Logging;
+
+use Linio\Common\Exception\CriticalError;
+use Linio\Common\Exception\DomainException;
+use PHPUnit\Framework\TestCase;
+
+class CriticalErrorProcessorTest extends TestCase
+{
+    public function testItUpgradesALogEntryToCritical(): void
+    {
+        $record = [
+            'level' => 400,
+            'levelName' => 'ERROR',
+            'context' => [
+                'exception' => new class('TOKEN') extends DomainException implements CriticalError {
+                },
+            ],
+        ];
+
+        $processor = new CriticalErrorProcessor();
+        $actual = $processor($record);
+
+        $this->assertSame(500, $actual['level']);
+        $this->assertSame('CRITICAL', $actual['levelName']);
+    }
+
+    public function testItIgnoresNonCriticalErrors(): void
+    {
+        $record = [
+            'level' => 400,
+            'levelName' => 'ERROR',
+        ];
+
+        $processor = new CriticalErrorProcessor();
+        $actual = $processor($record);
+
+        $this->assertSame(400, $actual['level']);
+        $this->assertSame('ERROR', $actual['levelName']);
+    }
+}

--- a/tests/Logging/DoNotLogHandlerTest.php
+++ b/tests/Logging/DoNotLogHandlerTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 
 class DoNotLogHandlerTest extends TestCase
 {
-    public function testItSkipsRecordsWithNoExceptions()
+    public function testItSkipsRecordsWithNoExceptions(): void
     {
         $handler = new DoNotLogHandler();
         $actual = $handler->handle([]);
@@ -18,7 +18,7 @@ class DoNotLogHandlerTest extends TestCase
         $this->assertFalse($actual);
     }
 
-    public function testItSkipsRecordsWithDoNotLog()
+    public function testItSkipsRecordsWithDoNotLog(): void
     {
         $exception = new ClientException('TEST');
 
@@ -28,9 +28,10 @@ class DoNotLogHandlerTest extends TestCase
         $this->assertTrue($actual);
     }
 
-    public function testItDoesNotSkipRecordsWithForceLogging()
+    public function testItDoesNotSkipRecordsWithForceLogging(): void
     {
-        $exception = new class('TEST') extends ClientException implements ForceLogging {};
+        $exception = new class('TEST') extends ClientException implements ForceLogging {
+        };
 
         $handler = new DoNotLogHandler();
         $actual = $handler->handle(['context' => ['exception' => $exception]]);

--- a/tests/Logging/DoNotLogHandlerTest.php
+++ b/tests/Logging/DoNotLogHandlerTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Linio\Common\Logging;
+
+use Linio\Common\Exception\ClientException;
+use Linio\Common\Exception\ForceLogging;
+use PHPUnit\Framework\TestCase;
+
+class DoNotLogHandlerTest extends TestCase
+{
+    public function testItSkipsRecordsWithNoExceptions()
+    {
+        $handler = new DoNotLogHandler();
+        $actual = $handler->handle([]);
+
+        $this->assertFalse($actual);
+    }
+
+    public function testItSkipsRecordsWithDoNotLog()
+    {
+        $exception = new ClientException('TEST');
+
+        $handler = new DoNotLogHandler();
+        $actual = $handler->handle(['context' => ['exception' => $exception]]);
+
+        $this->assertTrue($actual);
+    }
+
+    public function testItDoesNotSkipRecordsWithForceLogging()
+    {
+        $exception = new class('TEST') extends ClientException implements ForceLogging {};
+
+        $handler = new DoNotLogHandler();
+        $actual = $handler->handle(['context' => ['exception' => $exception]]);
+
+        $this->assertFalse($actual);
+    }
+}

--- a/tests/Logging/ExceptionTokenProcessorTest.php
+++ b/tests/Logging/ExceptionTokenProcessorTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Linio\Common\Logging;
+
+use Linio\Common\Exception\DomainException;
+use PHPUnit\Framework\TestCase;
+
+class ExceptionTokenProcessorTest extends TestCase
+{
+    public function testItAddsTheExceptionTokenToTheRecord(): void
+    {
+        $record = [
+            'context' => [
+                'exception' => new class('TOKEN') extends DomainException {
+                },
+            ],
+        ];
+
+        $processor = new ExceptionTokenProcessor();
+        $actual = $processor($record);
+
+        $this->assertSame('TOKEN', $actual['token']);
+    }
+
+    public function testItIgnoresRecordsWithoutADomainException(): void
+    {
+        $processor = new ExceptionTokenProcessor();
+        $actual = $processor([]);
+
+        $this->assertSame([], $actual);
+    }
+}

--- a/tests/Logging/ExceptionTokenProcessorTest.php
+++ b/tests/Logging/ExceptionTokenProcessorTest.php
@@ -23,12 +23,4 @@ class ExceptionTokenProcessorTest extends TestCase
 
         $this->assertSame('TOKEN', $actual['token']);
     }
-
-    public function testItIgnoresRecordsWithoutADomainException(): void
-    {
-        $processor = new ExceptionTokenProcessor();
-        $actual = $processor([]);
-
-        $this->assertSame([], $actual);
-    }
 }


### PR DESCRIPTION
This adds new base exceptions to the library. The intent is to clean up a lot of the duplication that we have across many libraries and applications, as well as:

* Cleanup duplication across libraries and applications
* Reduce complexity of inheritance for custom exceptions for critical/don't log
* Make it easy to ignore specific exceptions from being logged

One of the issues we've had is that each application would need to create their own DomainException, or whatever base exceptions, as well as our libraries. By including reasonable non-framework, non-http (primarily) based exceptions, we can easily use these everywhere.

Another issue was exception inheritance. If you look at some of the applications we have, we'd have no easy way to mark something as critical or non-critical, or tell Monolog to ignore specific exceptions. With these exceptions, we now have interfaces to be able to do that for us. Now if we want to have a bunch of exceptions extending for example `OrderException`, we can mark a child exception as either critical or make it logged/unlogged.

TODO (Discussion):

Currently I've implemented `CriticalException` and `ClientException` as a subclass of `DomainException`. The problem is that in a lot of our applications, we may have `OrderNotFoundException` extending `OrderException`, and thus can't make `OrderNotFoundException` a critical exception, nor mark it as a `ClientException` without affecting all the others.

Either we start using interfaces in our applications instead of a parent class like `OrderException`, or we need to use interfaces to mark an exception as critical and or client.

What do you all think?